### PR TITLE
3 fix failing tests in test user api

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -267,4 +267,12 @@ def login_request_data():
 
 @pytest.fixture
 async def user_token(user):
-    return create_access_token( data={"sub": user.email, "role": str(user.role)}, expires_delta=timedelta(minutes=settings.access_token_expire_minutes))
+    return create_access_token( data={"sub": user.email, "role": user.role.value}, expires_delta=timedelta(minutes=settings.access_token_expire_minutes))
+
+@pytest.fixture
+async def admin_token(admin_user):
+    return create_access_token(data={"sub": admin_user.email, "role": admin_user.role.value}, expires_delta=timedelta(minutes=settings.access_token_expire_minutes))
+
+@pytest.fixture
+async def manager_token(manager_user):
+    return create_access_token(data={"sub": manager_user.email, "role": manager_user.role.value}, expires_delta=timedelta(minutes=settings.access_token_expire_minutes))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,7 +15,7 @@ Fixtures:
 
 # Standard library imports
 from builtins import range
-from datetime import datetime
+from datetime import datetime, timedelta
 from unittest.mock import patch
 from uuid import uuid4
 
@@ -264,3 +264,7 @@ def user_response_data():
 @pytest.fixture
 def login_request_data():
     return {"email": "john.doe@example.com", "password": "SecurePassword123!"}
+
+@pytest.fixture
+async def user_token(user):
+    return create_access_token( data={"sub": user.email, "role": str(user.role)}, expires_delta=timedelta(minutes=settings.access_token_expire_minutes))


### PR DESCRIPTION
test_user_api failed because conftest was missing the required pytest fixtures for user_token, admin_token, and manager_token. After adding these fixtures, the tests passed.